### PR TITLE
Added sea level pressure calculation helper function

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -378,3 +378,23 @@ float Adafruit_BME280::readAltitude(float seaLevel)
   float atmospheric = readPressure() / 100.0F;
   return 44330.0 * (1.0 - pow(atmospheric / seaLevel, 0.1903));
 }
+
+/**************************************************************************/
+/*!
+    Calculates the pressure at sea level (in hPa) from the specified altitude 
+    (in meters), and atmospheric pressure (in hPa).  
+    @param  altitude      Altitude in meters
+    @param  atmospheric   Atmospheric pressure in hPa
+*/
+/**************************************************************************/
+float Adafruit_BME280::seaLevelForAltitude(float altitude, float atmospheric)
+{
+  // Equation taken from BMP180 datasheet (page 17):
+  //  http://www.adafruit.com/datasheets/BST-BMP180-DS000-09.pdf
+
+  // Note that using the equation from wikipedia can give bad results
+  // at high altitude.  See this thread for more information:
+  //  http://forums.adafruit.com/viewtopic.php?f=22&t=58064
+  
+  return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
+}

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -135,6 +135,7 @@ class Adafruit_BME280
     float readPressure(void);
     float readHumidity(void);
     float readAltitude(float seaLevel);
+    float seaLevelForAltitude(float altitude, float atmospheric);
 
   private:
 


### PR DESCRIPTION
Function for calculating the sea level pressure from the local pressure and altitude added. I've taken it from the [Adafruit BMP085 Unified Library](https://github.com/adafruit/Adafruit_BMP085_Unified/blob/master/Adafruit_BMP085_U.cpp#L416). I think that this library should also be able to do this calculation as the only difference of the two sensors is that the BME280 can additionally measure humidity.
