### PR TITLE
Burst reading from the same data sample, properly done

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -65,7 +65,7 @@ bool Adafruit_BME280::begin(uint8_t a) {
   readCoefficients();
 
   //Set before CONTROL_meas (DS 5.4.3)
-  write8(BME280_REGISTER_CONTROLHUMID, 0x05); //16x oversampling 
+  write8(BME280_REGISTER_CONTROLHUMID, 0x05); //16x oversampling
 
   write8(BME280_REGISTER_CONTROL, 0xB7); // 16x ovesampling, normal mode
   return true;
@@ -211,7 +211,7 @@ uint32_t Adafruit_BME280::read24(byte reg)
     Wire.write((uint8_t)reg);
     Wire.endTransmission();
     Wire.requestFrom((uint8_t)_i2caddr, (byte)3);
-    
+
     value = Wire.read();
     value <<= 8;
     value |= Wire.read();
@@ -223,7 +223,7 @@ uint32_t Adafruit_BME280::read24(byte reg)
       SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
     digitalWrite(_cs, LOW);
     spixfer(reg | 0x80); // read, bit 7 high
-    
+
     value = spixfer(0);
     value <<= 8;
     value |= spixfer(0);
@@ -238,6 +238,99 @@ uint32_t Adafruit_BME280::read24(byte reg)
   return value;
 }
 
+/**************************************************************************/
+/*!
+    @brief  Reads up to 3 24 bit values from the same sample in burst mode.
+*/
+/**************************************************************************/
+Adafruit_BME280::UncompensatedData Adafruit_BME280::readSensors(int readType)
+{
+  UncompensatedData results;
+  uint32_t value;
+  byte reg = BME280_REGISTER_TEMPDATA; // always start with this register
+  byte length = 3;
+  switch (readType) {
+    case READ_TPH:
+      length = 8;
+      break;
+    case READ_TP:
+      length = 6;
+      break;
+    // case READ_T:
+    // default:
+    //   length = 3;
+    //   break;
+  }
+
+  if (_cs == -1) {
+    Wire.beginTransmission((uint8_t)_i2caddr);
+    Wire.write((uint8_t)reg);
+    Wire.endTransmission();
+    Wire.requestFrom((uint8_t)_i2caddr, length);
+
+    //if (length > 0) {
+      value = Wire.read();
+      value <<= 8;
+      value |= Wire.read();
+      value <<= 8;
+      value |= Wire.read();
+      results.temp_ADC = value;
+    //}
+
+    //if (length > 3) {
+      value = Wire.read();
+      value <<= 8;
+      value |= Wire.read();
+      value <<= 8;
+      value |= Wire.read();
+      results.press_ADC = value;
+    //}
+
+    if (length > 6) {
+      value = Wire.read();
+      value <<= 8;
+      value |= Wire.read();
+      results.humid_ADC = value;
+    }
+
+  } else {
+    if (_sck == -1)
+      SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
+    digitalWrite(_cs, LOW);
+    spixfer(reg | 0x80); // read, bit 7 high
+
+    //if (length > 0) {
+      value = spixfer(0);
+      value <<= 8;
+      value |= spixfer(0);
+      value <<= 8;
+      value |= spixfer(0);
+      results.temp_ADC = value;
+    //}
+
+    //if (length > 3) {
+      value = spixfer(0);
+      value <<= 8;
+      value |= spixfer(0);
+      value <<= 8;
+      value |= spixfer(0);
+      results.press_ADC = value;
+    //}
+
+    if (length > 6) {
+      value = spixfer(0);
+      value <<= 8;
+      value |= spixfer(0);
+      results.humid_ADC = value;
+    }
+
+    digitalWrite(_cs, HIGH);
+    if (_sck == -1)
+      SPI.endTransaction();              // release the SPI bus
+  }
+
+  return results;
+}
 
 /**************************************************************************/
 /*!
@@ -270,14 +363,43 @@ void Adafruit_BME280::readCoefficients(void)
 
 /**************************************************************************/
 /*!
-
+    @brief  Read the sensor values, individually or as a group
 */
 /**************************************************************************/
-float Adafruit_BME280::readTemperature(void)
+float Adafruit_BME280::readTemperature(void) {
+  UncompensatedData results = readSensors(READ_T);
+  return compensateTemperature(results.temp_ADC);
+}
+
+float Adafruit_BME280::readPressure(void) {
+  UncompensatedData results = readSensors(READ_TP);
+  compensateTemperature(results.temp_ADC); // must be done first to get t_fine
+  return compensatePressure(results.press_ADC);
+}
+
+float Adafruit_BME280::readHumidity(void) {
+  UncompensatedData results = readSensors(READ_TPH);
+  compensateTemperature(results.temp_ADC); // must be done first to get t_fine
+  return compensateHumidity(results.humid_ADC);
+}
+
+void Adafruit_BME280::readAll(float *pT, float *pP, float *pH) {
+  UncompensatedData results = readSensors(READ_TPH);
+  float V = compensateTemperature(results.temp_ADC); // must be done first to get t_fine
+  if (pT) *pT = V;
+  if (pP) *pP = compensatePressure(results.press_ADC);
+  if (pH) *pH = compensateHumidity(results.humid_ADC);
+}
+
+/**************************************************************************/
+/*!
+  @brief  Converts raw temperature reading using factory compensation
+*/
+/**************************************************************************/
+float Adafruit_BME280::compensateTemperature(int32_t adc_T)
 {
   int32_t var1, var2;
 
-  int32_t adc_T = read24(BME280_REGISTER_TEMPDATA);
   adc_T >>= 4;
 
   var1  = ((((adc_T>>3) - ((int32_t)_bme280_calib.dig_T1 <<1))) *
@@ -295,15 +417,12 @@ float Adafruit_BME280::readTemperature(void)
 
 /**************************************************************************/
 /*!
-
+  @brief  Converts raw pressure reading using factory compensation
 */
 /**************************************************************************/
-float Adafruit_BME280::readPressure(void) {
+float Adafruit_BME280::compensatePressure(int32_t adc_P) {
   int64_t var1, var2, p;
 
-  readTemperature(); // must be done first to get t_fine
-
-  int32_t adc_P = read24(BME280_REGISTER_PRESSUREDATA);
   adc_P >>= 4;
 
   var1 = ((int64_t)t_fine) - 128000;
@@ -329,14 +448,10 @@ float Adafruit_BME280::readPressure(void) {
 
 /**************************************************************************/
 /*!
-
+  @brief  Converts raw humidity reading using factory compensation
 */
 /**************************************************************************/
-float Adafruit_BME280::readHumidity(void) {
-
-  readTemperature(); // must be done first to get t_fine
-
-  int32_t adc_H = read16(BME280_REGISTER_HUMIDDATA);
+float Adafruit_BME280::compensateHumidity(int32_t adc_H) {
 
   int32_t v_x1_u32r;
 
@@ -381,8 +496,8 @@ float Adafruit_BME280::readAltitude(float seaLevel)
 
 /**************************************************************************/
 /*!
-    Calculates the pressure at sea level (in hPa) from the specified altitude 
-    (in meters), and atmospheric pressure (in hPa).  
+    Calculates the pressure at sea level (in hPa) from the specified altitude
+    (in meters), and atmospheric pressure (in hPa).
     @param  altitude      Altitude in meters
     @param  atmospheric   Atmospheric pressure in hPa
 */
@@ -395,6 +510,6 @@ float Adafruit_BME280::seaLevelForAltitude(float altitude, float atmospheric)
   // Note that using the equation from wikipedia can give bad results
   // at high altitude.  See this thread for more information:
   //  http://forums.adafruit.com/viewtopic.php?f=22&t=58064
-  
+
   return atmospheric / pow(1.0 - (altitude/44330.0), 5.255);
 }

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -246,7 +246,6 @@ uint32_t Adafruit_BME280::read24(byte reg)
 Adafruit_BME280::UncompensatedData Adafruit_BME280::readSensors(int readType)
 {
   UncompensatedData results;
-  uint32_t value;
   byte reg = BME280_REGISTER_TEMPDATA; // always start with this register
   byte length = 3;
   switch (readType) {
@@ -269,28 +268,15 @@ Adafruit_BME280::UncompensatedData Adafruit_BME280::readSensors(int readType)
     Wire.requestFrom((uint8_t)_i2caddr, length);
 
     //if (length > 0) {
-      value = Wire.read();
-      value <<= 8;
-      value |= Wire.read();
-      value <<= 8;
-      value |= Wire.read();
-      results.temp_ADC = value;
+      results.temp_ADC = read24I2C(true);
     //}
 
     //if (length > 3) {
-      value = Wire.read();
-      value <<= 8;
-      value |= Wire.read();
-      value <<= 8;
-      value |= Wire.read();
-      results.press_ADC = value;
+      results.press_ADC = read24I2C(true);
     //}
 
     if (length > 6) {
-      value = Wire.read();
-      value <<= 8;
-      value |= Wire.read();
-      results.humid_ADC = value;
+      results.humid_ADC = read24I2C(false);
     }
 
   } else {
@@ -300,28 +286,15 @@ Adafruit_BME280::UncompensatedData Adafruit_BME280::readSensors(int readType)
     spixfer(reg | 0x80); // read, bit 7 high
 
     //if (length > 0) {
-      value = spixfer(0);
-      value <<= 8;
-      value |= spixfer(0);
-      value <<= 8;
-      value |= spixfer(0);
-      results.temp_ADC = value;
+      results.temp_ADC = read24SPI(true);
     //}
 
     //if (length > 3) {
-      value = spixfer(0);
-      value <<= 8;
-      value |= spixfer(0);
-      value <<= 8;
-      value |= spixfer(0);
-      results.press_ADC = value;
+      results.press_ADC = read24SPI(true);
     //}
 
     if (length > 6) {
-      value = spixfer(0);
-      value <<= 8;
-      value |= spixfer(0);
-      results.humid_ADC = value;
+      results.humid_ADC = read24SPI(false);
     }
 
     digitalWrite(_cs, HIGH);
@@ -330,6 +303,32 @@ Adafruit_BME280::UncompensatedData Adafruit_BME280::readSensors(int readType)
   }
 
   return results;
+}
+
+uint32_t Adafruit_BME280::read24I2C(bool all_3_bytes) {
+  uint32_t value;
+
+  value = Wire.read();
+  value <<= 8;
+  value |= Wire.read();
+  if (!all_3_bytes) {
+    value <<= 8;
+    value |= Wire.read();
+  }
+  return value;
+}
+
+uint32_t Adafruit_BME280::read24SPI(bool all_3_bytes) {
+  uint32_t value;
+
+  value = spixfer(0);
+  value <<= 8;
+  value |= spixfer(0);
+  if (!all_3_bytes) {
+    value <<= 8;
+    value |= spixfer(0);
+  }
+  return value;
 }
 
 /**************************************************************************/

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -164,6 +164,8 @@ class Adafruit_BME280
     } UncompensatedData;
     enum { READ_T, READ_TP, READ_TPH };
     UncompensatedData readSensors(int readType);
+    uint32_t read24I2C(bool all_3_bytes);
+    uint32_t read24SPI(bool all_3_bytes);
 
     uint8_t   _i2caddr;
     int32_t   _sensorID;

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -162,10 +162,11 @@ class Adafruit_BME280
       uint32_t press_ADC;
       uint32_t humid_ADC;
     } UncompensatedData;
-    enum { READ_T, READ_TP, READ_TPH };
+    enum { READ_T, READ_PT, READ_TH, READ_PTH };
     UncompensatedData readSensors(int readType);
-    uint32_t read24I2C(bool all_3_bytes);
-    uint32_t read24SPI(bool all_3_bytes);
+
+    uint32_t _readIntI2C(bool read_3rd_byte);
+    uint32_t _readIntSPI(bool read_3rd_byte);
 
     uint8_t   _i2caddr;
     int32_t   _sensorID;

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -137,6 +137,10 @@ class Adafruit_BME280
     float readAltitude(float seaLevel);
     float seaLevelForAltitude(float altitude, float atmospheric);
 
+    // function to efficiently read all sensors at once
+    // if a particular pointer is NULL, it is ignored
+    void readAll(float *pTemperature, float *pPressure, float *pHumidity);
+
   private:
 
     void readCoefficients(void);
@@ -149,6 +153,17 @@ class Adafruit_BME280
     int16_t   readS16(byte reg);
     uint16_t  read16_LE(byte reg); // little endian
     int16_t   readS16_LE(byte reg); // little endian
+
+    float compensateTemperature(int32_t adc_T);
+    float compensatePressure(int32_t adc_P);
+    float compensateHumidity(int32_t adc_H);
+    typedef struct {
+      uint32_t temp_ADC;
+      uint32_t press_ADC;
+      uint32_t humid_ADC;
+    } UncompensatedData;
+    enum { READ_T, READ_TP, READ_TPH };
+    UncompensatedData readSensors(int readType);
 
     uint8_t   _i2caddr;
     int32_t   _sensorID;


### PR DESCRIPTION
The existing code runs separate burst reads for Temperature and Pressure/Humidity. This could lead to the values coming from different samples, if a new one became available in between the reads.

In order to fix this (see BME280 Datasheet section 4 and 4.1), I added a new private function based on read24() to read all the data registers at once. I allow the calling code to specify how many values need to be read (1, 2, or 3, in order). Then, I modified the calling methods for the compensation code so that it can be called separately. Finally, I rewrote the readX() code to call the new function. And I added a new public function readAll() to allow more than one value to be read from the same sample at once.

Since this is based only on the behavior described in the data sheet, it should run on all platforms that the original code ran on. In my tests, it adds 310 bytes of program storage when compiled for the Uno.

My editor (Atom) also seems to have trimmed some blanks or tabs on a few lines without my intention.

NOTE: The code in here should be compatible with PR#13 from @mozzbozz that is in progress. (See our discussions there.)
