### PR TITLE
change loop to delay so ESP8266 can do Wi-Fi tasks

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -303,7 +303,8 @@ void Adafruit_BME280::takeForcedMeasurement()
         write8(BME280_REGISTER_CONTROL, _measReg.get());
         // wait until measurement has been completed, otherwise we would read
         // the values from the last measurement
-        while (read8(BME280_REGISTER_STATUS) & 0x08);
+        while (read8(BME280_REGISTER_STATUS) & 0x08)
+		delay(1);
     }
 }
 


### PR DESCRIPTION
delay(1) allows ESP8266 to do Wi-Fi tasks. It is recommended to not make any code that blocks this for more than 20/50 miliseconds.
Tested on ESP8266.

Simple test:
`long test=millis();
bme.takeForcedMeasurement();
Serial.println(millis()-test);`
shows that with X16 oversampling, bme.takeForceMeasurement can block for 70ms (and even over 100ms for first measurement after reset).

https://github.com/esp8266/Arduino/issues/2021
https://github.com/esp8266/Arduino/blob/master/doc/reference.md#timing-and-delays