### PR TITLE
Reset on begin and read coefficients only after calibration

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -77,7 +77,7 @@ bool Adafruit_BME280::begin(uint8_t           addr)
     while (isReadingCalibration())
           delay(100);
 
-    readCoefficients();
+    readCoefficients(); // read trimming parameters, see DS 4.2.2
 
     setSampling(); // use defaults
 

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -66,8 +66,19 @@ bool Adafruit_BME280::begin(uint8_t           addr)
     if (read8(BME280_REGISTER_CHIPID) != 0x60)
         return false;
 
-    readCoefficients(); // read trimming parameters, see DS 4.2.2
-    
+    // reset the device using soft-reset
+    // this makes sure the IIR is off, etc.
+    write8(BME280_REGISTER_SOFTRESET, 0xB6);
+
+    // wait for chip to wake up.
+    delay(300);
+
+    // if chip is still reading calibration, delay
+    while (isReadingCalibration())
+          delay(100);
+
+    readCoefficients();
+
     setSampling(); // use defaults
 
     return true;
@@ -336,6 +347,18 @@ void Adafruit_BME280::readCoefficients(void)
     _bme280_calib.dig_H4 = (read8(BME280_REGISTER_DIG_H4) << 4) | (read8(BME280_REGISTER_DIG_H4+1) & 0xF);
     _bme280_calib.dig_H5 = (read8(BME280_REGISTER_DIG_H5+1) << 4) | (read8(BME280_REGISTER_DIG_H5) >> 4);
     _bme280_calib.dig_H6 = (int8_t)read8(BME280_REGISTER_DIG_H6);
+}
+
+/**************************************************************************/
+/*!
+    @brief return true if chip is busy reading cal data
+*/
+/**************************************************************************/
+bool Adafruit_BME280::isReadingCalibration(void)
+{
+  uint8_t const rStatus = read8(BME280_REGISTER_STATUS);
+
+  return (rStatus & (1 << 0)) != 0;
 }
 
 

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -187,6 +187,7 @@ class Adafruit_BME280 {
         
     private:
         void readCoefficients(void);
+        bool isReadingCalibration(void);
         uint8_t spixfer(uint8_t x);
 
         void      write8(byte reg, byte value);


### PR DESCRIPTION
We added a soft reset on begin() in order to put the sensor in a known state. Following reset, it is necessary to wait for calibration to complete. Thankfully, the chip offers a status bit to read to detect when it is performing calibration.

In Adafruit_BME280::begin(addr)
- Added soft reset call following comms initialization
- Added delay for reset to complete
- Added loop awaiting calibration

In class Adafruit_BME280
- Added status method isReadingCalibration()

Limitations: No known limitations. All code uses existing hardware comms layer and standard library calls (eg delay).
Testing: Library examples run as usual.
