### PR TITLE
Made the Wire Bus selectable in setup

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -40,14 +40,33 @@ Adafruit_BME280::Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin, i
     @brief  Initialise sensor with given parameters / settings
 */
 /**************************************************************************/
-bool Adafruit_BME280::begin(uint8_t           addr)
+bool Adafruit_BME280::begin(TwoWire *theWire)
+{
+	_wire = theWire;
+	_i2caddr = BME280_ADDRESS;
+	return init();
+}
+
+bool Adafruit_BME280::begin(uint8_t addr)
+{
+	_i2caddr = addr;
+	_wire = &Wire;
+	return init();
+}
+
+bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire)
 {
     _i2caddr = addr;
+	_wire = theWire;
+	return init();
+}
 
+bool Adafruit_BME280::init()
+{
     // init I2C or SPI sensor interface
     if (_cs == -1) {
         // I2C
-        Wire.begin();
+        _wire -> begin();
     } else {
         digitalWrite(_cs, HIGH);
         pinMode(_cs, OUTPUT);
@@ -149,10 +168,10 @@ uint8_t Adafruit_BME280::spixfer(uint8_t x) {
 /**************************************************************************/
 void Adafruit_BME280::write8(byte reg, byte value) {
     if (_cs == -1) {
-        Wire.beginTransmission((uint8_t)_i2caddr);
-        Wire.write((uint8_t)reg);
-        Wire.write((uint8_t)value);
-        Wire.endTransmission();
+        _wire -> beginTransmission((uint8_t)_i2caddr);
+        _wire -> write((uint8_t)reg);
+        _wire -> write((uint8_t)value);
+        _wire -> endTransmission();
     } else {
         if (_sck == -1)
             SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
@@ -175,11 +194,11 @@ uint8_t Adafruit_BME280::read8(byte reg) {
     uint8_t value;
     
     if (_cs == -1) {
-        Wire.beginTransmission((uint8_t)_i2caddr);
-        Wire.write((uint8_t)reg);
-        Wire.endTransmission();
-        Wire.requestFrom((uint8_t)_i2caddr, (byte)1);
-        value = Wire.read();
+        _wire -> beginTransmission((uint8_t)_i2caddr);
+        _wire -> write((uint8_t)reg);
+        _wire -> endTransmission();
+        _wire -> requestFrom((uint8_t)_i2caddr, (byte)1);
+        value = _wire -> read();
     } else {
         if (_sck == -1)
             SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
@@ -204,11 +223,11 @@ uint16_t Adafruit_BME280::read16(byte reg)
     uint16_t value;
 
     if (_cs == -1) {
-        Wire.beginTransmission((uint8_t)_i2caddr);
-        Wire.write((uint8_t)reg);
-        Wire.endTransmission();
-        Wire.requestFrom((uint8_t)_i2caddr, (byte)2);
-        value = (Wire.read() << 8) | Wire.read();
+        _wire -> beginTransmission((uint8_t)_i2caddr);
+        _wire -> write((uint8_t)reg);
+        _wire -> endTransmission();
+        _wire -> requestFrom((uint8_t)_i2caddr, (byte)2);
+        value = (_wire -> read() << 8) | _wire -> read();
     } else {
         if (_sck == -1)
             SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));
@@ -267,16 +286,16 @@ uint32_t Adafruit_BME280::read24(byte reg)
     uint32_t value;
 
     if (_cs == -1) {
-        Wire.beginTransmission((uint8_t)_i2caddr);
-        Wire.write((uint8_t)reg);
-        Wire.endTransmission();
-        Wire.requestFrom((uint8_t)_i2caddr, (byte)3);
+        _wire -> beginTransmission((uint8_t)_i2caddr);
+        _wire -> write((uint8_t)reg);
+        _wire -> endTransmission();
+        _wire -> requestFrom((uint8_t)_i2caddr, (byte)3);
 
-        value = Wire.read();
+        value = _wire -> read();
         value <<= 8;
-        value |= Wire.read();
+        value |= _wire -> read();
         value <<= 8;
-        value |= Wire.read();
+        value |= _wire -> read();
     } else {
         if (_sck == -1)
             SPI.beginTransaction(SPISettings(500000, MSBFIRST, SPI_MODE0));

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -61,6 +61,13 @@ bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire)
 	return init();
 }
 
+bool Adafruit_BME280::begin(void)
+{
+    _i2caddr = BME280_ADDRESS;
+	_wire = &Wire;
+	return init();
+}
+
 bool Adafruit_BME280::init()
 {
     // init I2C or SPI sensor interface

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -166,7 +166,10 @@ class Adafruit_BME280 {
         Adafruit_BME280(int8_t cspin);
         Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
         
-        bool  begin(uint8_t addr                  = BME280_ADDRESS);
+		bool begin(TwoWire *theWire);
+		bool begin(uint8_t addr = BME280_ADDRESS);
+        bool begin(uint8_t addr = BME280_ADDRESS, TwoWire *theWire = &Wire);
+		bool init();
 
 	void setSampling(sensor_mode mode              = MODE_NORMAL,
 			 sensor_sampling tempSampling  = SAMPLING_X16,
@@ -186,6 +189,7 @@ class Adafruit_BME280 {
 
         
     private:
+		TwoWire *_wire;
         void readCoefficients(void);
         bool isReadingCalibration(void);
         uint8_t spixfer(uint8_t x);

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -165,10 +165,11 @@ class Adafruit_BME280 {
         Adafruit_BME280(void);
         Adafruit_BME280(int8_t cspin);
         Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
-        
+		
+		bool begin(void);
 		bool begin(TwoWire *theWire);
-		bool begin(uint8_t addr = BME280_ADDRESS);
-        bool begin(uint8_t addr = BME280_ADDRESS, TwoWire *theWire = &Wire);
+		bool begin(uint8_t addr);
+        bool begin(uint8_t addr, TwoWire *theWire);
 		bool init();
 
 	void setSampling(sensor_mode mode              = MODE_NORMAL,

--- a/examples/advancedsettings/advancedsettings.ino
+++ b/examples/advancedsettings/advancedsettings.ino
@@ -37,7 +37,7 @@ void setup() {
     Serial.begin(9600);
     Serial.println(F("BME280 test"));
 
-    if (! bme.begin()) {
+    if (! bme.begin(&Wire1)) {
         Serial.println("Could not find a valid BME280 sensor, check wiring!");
         while (1);
     }

--- a/examples/bme280test/bme280test.ino
+++ b/examples/bme280test/bme280test.ino
@@ -40,7 +40,7 @@ void setup() {
     bool status;
     
     // default settings
-    status = bme.begin();
+    status = bme.begin(&Wire1);
     if (!status) {
         Serial.println("Could not find a valid BME280 sensor, check wiring!");
         while (1);


### PR DESCRIPTION
Scope of Change:
Add the compatibility to select which Wire bus you would like to use with the sensor. For instance:
to use specify bme.begin(&Wire) . Or, bme.begin(BME280 Address) which just uses the default Wire.  Or bme.begin(BME280 Address, &Wire1) which sets both. If you want to can use Wire2 (Teensy 3.5/3.6 have Wire, Wire1, Wire2 that you can use.

Limitation:
The only limitation is that there is no default test if you select a Wire port that is not available. 

Test:
Ran a test on the Teensy 3.5 with the sensor on Wire1 and worked fine.

Thanks for considering this change
Mike