### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Atmega328 @ 16MHz  |      X       |             |            |
 Atmega328 @ 12MHz  |      X       |             |            | 
 Atmega32u4 @ 16MHz |      X       |             |            | Use SDA/SCL on pins D2 &amp; D3
 Atmega32u4 @ 8MHz  |      X       |             |            | Use SDA/SCL on pins D2 &amp; D3
-ESP8266            |      X       |             |            | I2C: just works, SPI: SDA/SCL default to pins 4 &amp; 5 but any two pins can be assigned as SDA/SCL using Wire.begin(SDA,SCL)
-ESP32              |      X       |             |            | I2C: just works, SPI: SDA/SCL default to pins 4 &amp; 5 but any two pins can be assigned as SDA/SCL using Wire.begin(SDA,SCL) 
+ESP8266            |      X       |             |            | I2C: just works: SDA/SCL default to pins 4 &amp; 5 but any two pins can be assigned as SDA/SCL using Wire.begin(SDA,SCL)
+ESP32              |      X       |             |            | I2C: just works: SDA/SCL default to pins 4 &amp; 5 but any two pins can be assigned as SDA/SCL using Wire.begin(SDA,SCL) 
 Atmega2560 @ 16MHz |      X       |             |            | Use SDA/SCL on pins 20 &amp; 21
 ATSAM3X8E          |      X       |             |            | Use SDA/SCL on pins 20 &amp; 21
 ATSAM21D           |      X       |             |            | 


### PR DESCRIPTION
"SPI:" text is incorrect as I read it, and its inclusion lead me to explore other libraries for software based I2C when this one was sitting right in front of me. This edit removes ", SPI" from the documentation.

This is a documentation only change and does not affect the code.