### PR TITLE
Add LICENSE and mention it in all source files

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -24,6 +24,7 @@
  * @section license License
  *
  * BSD license, all text here must be included in any redistribution.
+ * See the LICENSE file for details.
  *
  */
 

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -14,6 +14,7 @@
  * Written by Kevin "KTOWN" Townsend for Adafruit Industries.
  *
  * BSD license, all text here must be included in any redistribution.
+ * See the LICENSE file for details.
  *
  */
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019, Kevin "KTOWN" Townsend for Adafruit Industries 
+Copyright (c) 2015, Limor Fried & Kevin Townsend for Adafruit Industries 
 All rights reserved. 
 
 Redistribution and use in source and binary forms, with or without 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2019, Kevin "KTOWN" Townsend for Adafruit Industries 
+All rights reserved. 
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met: 
+
+ * Redistributions of source code must retain the above copyright notice, 
+   this list of conditions and the following disclaimer. 
+ * Redistributions in binary form must reproduce the above copyright 
+   notice, this list of conditions and the following disclaimer in the 
+   documentation and/or other materials provided with the distribution. 
+ * Neither the name of Adafruit Industries nor the names of its 
+   contributors may be used to endorse or promote products derived from 
+   this software without specific prior written permission. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
+POSSIBILITY OF SUCH DAMAGE.
+

--- a/examples/advancedsettings/advancedsettings.ino
+++ b/examples/advancedsettings/advancedsettings.ino
@@ -13,6 +13,7 @@
 
   Written by Limor Fried & Kevin Townsend for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
+  See the LICENSE file for details.
  ***************************************************************************/
 
 #include <Wire.h>

--- a/examples/bme280test/bme280test.ino
+++ b/examples/bme280test/bme280test.ino
@@ -13,6 +13,7 @@
 
   Written by Limor Fried & Kevin Townsend for Adafruit Industries.
   BSD license, all text above must be included in any redistribution
+  See the LICENSE file for details.
  ***************************************************************************/
 
 #include <Wire.h>


### PR DESCRIPTION
Add a LICENSE file and mention it in all source files. License text is generated with this tool:
https://soulsphere.org/hacks/bsd/

The source files mention the BSD license, but they don't say _which version_ of the BSD license; there are 3 different BSD licenses:
- 2 clause BSD license
- 3 clause BSD license ("New BSD", with endorsement clause, used in this PR)
- 4 clause BSD license ("Original BSD", with marketing clause)

The 4 clause BSD license is the most restrictive, and it's considered problematic, because it requires mentioning the University of California, Berkeley in all marketing.

The 3 clause license is the most commonly used, and the only addition compared to the 2 clause license is that using Adafruit's or other authors' names for endorsement/promotion of derived software is not allowed without written permission (probably a good idea, even if Adafruit's trademark probably already prevents this).

-----

A LICENSE file is pretty common practice, and it's the first place where most people look for the license. It's also important to include the full text of the license somewhere, since now it's unclear which BSD license the source files refer to.

I'd suggest adding a LICENSE file to all Adafruit libraries.