### PR TITLE
Bmp280 support

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -404,9 +404,9 @@ void Adafruit_BME280::readCoefficients(void) {
   _bme280_calib.dig_H1 = read8(BME280_REGISTER_DIG_H1);
   _bme280_calib.dig_H2 = readS16_LE(BME280_REGISTER_DIG_H2);
   _bme280_calib.dig_H3 = read8(BME280_REGISTER_DIG_H3);
-  _bme280_calib.dig_H4 = (read8(BME280_REGISTER_DIG_H4) << 4) |
+  _bme280_calib.dig_H4 = ((int8_t)read8(BME280_REGISTER_DIG_H4) << 4) |
                          (read8(BME280_REGISTER_DIG_H4 + 1) & 0xF);
-  _bme280_calib.dig_H5 = (read8(BME280_REGISTER_DIG_H5 + 1) << 4) |
+  _bme280_calib.dig_H5 = ((int8_t)read8(BME280_REGISTER_DIG_H5 + 1) << 4) |
                          (read8(BME280_REGISTER_DIG_H5) >> 4);
   _bme280_calib.dig_H6 = (int8_t)read8(BME280_REGISTER_DIG_H6);
 }

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -311,13 +311,6 @@ uint16_t Adafruit_BME280::read16_LE(byte reg) {
 }
 
 /*!
- *   @brief  Reads a signed 16 bit value over I2C or SPI
- *   @param reg the register address to read from
- *   @returns the 16 bit data value read from the device
- */
-int16_t Adafruit_BME280::readS16(byte reg) { return (int16_t)read16(reg); }
-
-/*!
  *   @brief  Reads a signed little endian 16 bit value over I2C or SPI
  *   @param reg the register address to read from
  *   @returns the 16 bit data value read from the device

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -380,28 +380,28 @@ void Adafruit_BME280::takeForcedMeasurement() {
  *   @brief  Reads the factory-set coefficients
  */
 void Adafruit_BME280::readCoefficients(void) {
-  _bme280_calib.dig_T1 = read16_LE(BME280_REGISTER_DIG_T1);
-  _bme280_calib.dig_T2 = readS16_LE(BME280_REGISTER_DIG_T2);
-  _bme280_calib.dig_T3 = readS16_LE(BME280_REGISTER_DIG_T3);
+  dig_T1 = read16_LE(BME280_REGISTER_DIG_T1);
+  dig_T2 = readS16_LE(BME280_REGISTER_DIG_T2);
+  dig_T3 = readS16_LE(BME280_REGISTER_DIG_T3);
 
-  _bme280_calib.dig_P1 = read16_LE(BME280_REGISTER_DIG_P1);
-  _bme280_calib.dig_P2 = readS16_LE(BME280_REGISTER_DIG_P2);
-  _bme280_calib.dig_P3 = readS16_LE(BME280_REGISTER_DIG_P3);
-  _bme280_calib.dig_P4 = readS16_LE(BME280_REGISTER_DIG_P4);
-  _bme280_calib.dig_P5 = readS16_LE(BME280_REGISTER_DIG_P5);
-  _bme280_calib.dig_P6 = readS16_LE(BME280_REGISTER_DIG_P6);
-  _bme280_calib.dig_P7 = readS16_LE(BME280_REGISTER_DIG_P7);
-  _bme280_calib.dig_P8 = readS16_LE(BME280_REGISTER_DIG_P8);
-  _bme280_calib.dig_P9 = readS16_LE(BME280_REGISTER_DIG_P9);
+  dig_P1 = read16_LE(BME280_REGISTER_DIG_P1);
+  dig_P2 = readS16_LE(BME280_REGISTER_DIG_P2);
+  dig_P3 = readS16_LE(BME280_REGISTER_DIG_P3);
+  dig_P4 = readS16_LE(BME280_REGISTER_DIG_P4);
+  dig_P5 = readS16_LE(BME280_REGISTER_DIG_P5);
+  dig_P6 = readS16_LE(BME280_REGISTER_DIG_P6);
+  dig_P7 = readS16_LE(BME280_REGISTER_DIG_P7);
+  dig_P8 = readS16_LE(BME280_REGISTER_DIG_P8);
+  dig_P9 = readS16_LE(BME280_REGISTER_DIG_P9);
 
-  _bme280_calib.dig_H1 = read8(BME280_REGISTER_DIG_H1);
-  _bme280_calib.dig_H2 = readS16_LE(BME280_REGISTER_DIG_H2);
-  _bme280_calib.dig_H3 = read8(BME280_REGISTER_DIG_H3);
-  _bme280_calib.dig_H4 = ((int8_t)read8(BME280_REGISTER_DIG_H4) << 4) |
+  dig_H1 = read8(BME280_REGISTER_DIG_H1);
+  dig_H2 = readS16_LE(BME280_REGISTER_DIG_H2);
+  dig_H3 = read8(BME280_REGISTER_DIG_H3);
+  dig_H4 = ((int8_t)read8(BME280_REGISTER_DIG_H4) << 4) |
                          (read8(BME280_REGISTER_DIG_H4 + 1) & 0xF);
-  _bme280_calib.dig_H5 = ((int8_t)read8(BME280_REGISTER_DIG_H5 + 1) << 4) |
+  dig_H5 = ((int8_t)read8(BME280_REGISTER_DIG_H5 + 1) << 4) |
                          (read8(BME280_REGISTER_DIG_H5) >> 4);
-  _bme280_calib.dig_H6 = (int8_t)read8(BME280_REGISTER_DIG_H6);
+  dig_H6 = (int8_t)read8(BME280_REGISTER_DIG_H6);
 }
 
 /*!
@@ -426,14 +426,14 @@ float Adafruit_BME280::readTemperature(void) {
     return NAN;
   adc_T >>= 4;
 
-  var1 = ((((adc_T >> 3) - ((int32_t)_bme280_calib.dig_T1 << 1))) *
-          ((int32_t)_bme280_calib.dig_T2)) >>
+  var1 = ((((adc_T >> 3) - ((int32_t)dig_T1 << 1))) *
+          ((int32_t)dig_T2)) >>
          11;
 
-  var2 = (((((adc_T >> 4) - ((int32_t)_bme280_calib.dig_T1)) *
-            ((adc_T >> 4) - ((int32_t)_bme280_calib.dig_T1))) >>
+  var2 = (((((adc_T >> 4) - ((int32_t)dig_T1)) *
+            ((adc_T >> 4) - ((int32_t)dig_T1))) >>
            12) *
-          ((int32_t)_bme280_calib.dig_T3)) >>
+          ((int32_t)dig_T3)) >>
          14;
 
   t_fine = var1 + var2;
@@ -457,23 +457,23 @@ float Adafruit_BME280::readPressure(void) {
   adc_P >>= 4;
 
   var1 = ((int64_t)t_fine) - 128000;
-  var2 = var1 * var1 * (int64_t)_bme280_calib.dig_P6;
-  var2 = var2 + ((var1 * (int64_t)_bme280_calib.dig_P5) << 17);
-  var2 = var2 + (((int64_t)_bme280_calib.dig_P4) << 35);
-  var1 = ((var1 * var1 * (int64_t)_bme280_calib.dig_P3) >> 8) +
-         ((var1 * (int64_t)_bme280_calib.dig_P2) << 12);
+  var2 = var1 * var1 * (int64_t)dig_P6;
+  var2 = var2 + ((var1 * (int64_t)dig_P5) << 17);
+  var2 = var2 + (((int64_t)dig_P4) << 35);
+  var1 = ((var1 * var1 * (int64_t)dig_P3) >> 8) +
+         ((var1 * (int64_t)dig_P2) << 12);
   var1 =
-      (((((int64_t)1) << 47) + var1)) * ((int64_t)_bme280_calib.dig_P1) >> 33;
+      (((((int64_t)1) << 47) + var1)) * ((int64_t)dig_P1) >> 33;
 
   if (var1 == 0) {
     return 0; // avoid exception caused by division by zero
   }
   p = 1048576 - adc_P;
   p = (((p << 31) - var2) * 3125) / var1;
-  var1 = (((int64_t)_bme280_calib.dig_P9) * (p >> 13) * (p >> 13)) >> 25;
-  var2 = (((int64_t)_bme280_calib.dig_P8) * p) >> 19;
+  var1 = (((int64_t)dig_P9) * (p >> 13) * (p >> 13)) >> 25;
+  var2 = (((int64_t)dig_P8) * p) >> 19;
 
-  p = ((p + var1 + var2) >> 8) + (((int64_t)_bme280_calib.dig_P7) << 4);
+  p = ((p + var1 + var2) >> 8) + (((int64_t)dig_P7) << 4);
   return (float)p / 256;
 }
 
@@ -492,21 +492,21 @@ float Adafruit_BME280::readHumidity(void) {
 
   v_x1_u32r = (t_fine - ((int32_t)76800));
 
-  v_x1_u32r = (((((adc_H << 14) - (((int32_t)_bme280_calib.dig_H4) << 20) -
-                  (((int32_t)_bme280_calib.dig_H5) * v_x1_u32r)) +
+  v_x1_u32r = (((((adc_H << 14) - (((int32_t)dig_H4) << 20) -
+                  (((int32_t)dig_H5) * v_x1_u32r)) +
                  ((int32_t)16384)) >>
                 15) *
-               (((((((v_x1_u32r * ((int32_t)_bme280_calib.dig_H6)) >> 10) *
-                    (((v_x1_u32r * ((int32_t)_bme280_calib.dig_H3)) >> 11) +
+               (((((((v_x1_u32r * ((int32_t)dig_H6)) >> 10) *
+                    (((v_x1_u32r * ((int32_t)dig_H3)) >> 11) +
                      ((int32_t)32768))) >>
                    10) +
                   ((int32_t)2097152)) *
-                     ((int32_t)_bme280_calib.dig_H2) +
+                     ((int32_t)dig_H2) +
                  8192) >>
                 14));
 
   v_x1_u32r = (v_x1_u32r - (((((v_x1_u32r >> 15) * (v_x1_u32r >> 15)) >> 7) *
-                             ((int32_t)_bme280_calib.dig_H1)) >>
+                             ((int32_t)dig_H1)) >>
                             4));
 
   v_x1_u32r = (v_x1_u32r < 0) ? 0 : v_x1_u32r;

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -33,6 +33,11 @@
 #include <SPI.h>
 #include <Wire.h>
 
+enum {
+  BMP280_SENSOR_ID = 0x58,
+  BME280_SENSOR_ID = 0x60
+};
+
 /*!
  *  @brief  class constructor
  */
@@ -136,7 +141,7 @@ bool Adafruit_BME280::init() {
 
   // check if sensor, i.e. the chip ID is correct
   _sensorID = read8(BME280_REGISTER_CHIPID);
-  if (_sensorID != 0x60)
+  if (_sensorID != BME280_SENSOR_ID)
     return false;
 
   // reset the device using soft-reset

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -76,33 +76,6 @@ enum {
   BME280_REGISTER_HUMIDDATA = 0xFD
 };
 
-/**************************************************************************/
-/*!
-    @brief  calibration data
-*/
-/**************************************************************************/
-typedef struct {
-  uint16_t dig_T1; ///< temperature compensation value
-  int16_t dig_T2;  ///< temperature compensation value
-  int16_t dig_T3;  ///< temperature compensation value
-
-  uint16_t dig_P1; ///< pressure compensation value
-  int16_t dig_P2;  ///< pressure compensation value
-  int16_t dig_P3;  ///< pressure compensation value
-  int16_t dig_P4;  ///< pressure compensation value
-  int16_t dig_P5;  ///< pressure compensation value
-  int16_t dig_P6;  ///< pressure compensation value
-  int16_t dig_P7;  ///< pressure compensation value
-  int16_t dig_P8;  ///< pressure compensation value
-  int16_t dig_P9;  ///< pressure compensation value
-
-  int16_t dig_H2; ///< humidity compensation value
-  int16_t dig_H4; ///< humidity compensation value
-  int16_t dig_H5; ///< humidity compensation value
-  uint8_t dig_H1; ///< humidity compensation value
-  uint8_t dig_H3; ///< humidity compensation value
-  int8_t dig_H6;  ///< humidity compensation value
-} bme280_calib_data;
 /*=========================================================================*/
 
 /*
@@ -233,14 +206,33 @@ protected:
   int32_t t_fine; //!< temperature with high resolution, stored as an attribute
                   //!< as this is used for temperature compensation reading
                   //!< humidity and pressure
-  uint8_t _i2caddr;  //!< I2C addr for the TwoWire interface
-
   int8_t _cs;   //!< for the SPI interface
   int8_t _mosi; //!< for the SPI interface
   int8_t _miso; //!< for the SPI interface
   int8_t _sck;  //!< for the SPI interface
 
-  bme280_calib_data _bme280_calib; //!< here calibration data is stored
+  uint16_t dig_T1; ///< temperature compensation value
+  int16_t dig_T2;  ///< temperature compensation value
+  int16_t dig_T3;  ///< temperature compensation value
+
+  uint16_t dig_P1; ///< pressure compensation value
+  int16_t dig_P2;  ///< pressure compensation value
+  int16_t dig_P3;  ///< pressure compensation value
+  int16_t dig_P4;  ///< pressure compensation value
+  int16_t dig_P5;  ///< pressure compensation value
+  int16_t dig_P6;  ///< pressure compensation value
+  int16_t dig_P7;  ///< pressure compensation value
+  int16_t dig_P8;  ///< pressure compensation value
+  int16_t dig_P9;  ///< pressure compensation value
+
+  int16_t dig_H2; ///< humidity compensation value
+  int16_t dig_H4; ///< humidity compensation value
+  int16_t dig_H5; ///< humidity compensation value
+  uint8_t dig_H1; ///< humidity compensation value
+  uint8_t dig_H3; ///< humidity compensation value
+  int8_t dig_H6;  ///< humidity compensation value
+
+  uint8_t _i2caddr;  //!< I2C addr for the TwoWire interface
 
   /**************************************************************************/
   /*!

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -96,11 +96,11 @@ typedef struct {
   int16_t dig_P8;  ///< pressure compensation value
   int16_t dig_P9;  ///< pressure compensation value
 
-  uint8_t dig_H1; ///< humidity compensation value
   int16_t dig_H2; ///< humidity compensation value
-  uint8_t dig_H3; ///< humidity compensation value
   int16_t dig_H4; ///< humidity compensation value
   int16_t dig_H5; ///< humidity compensation value
+  uint8_t dig_H1; ///< humidity compensation value
+  uint8_t dig_H3; ///< humidity compensation value
   int8_t dig_H6;  ///< humidity compensation value
 } bme280_calib_data;
 /*=========================================================================*/
@@ -230,11 +230,11 @@ protected:
   uint16_t read16_LE(byte reg); // little endian
   int16_t readS16_LE(byte reg); // little endian
 
-  uint8_t _i2caddr;  //!< I2C addr for the TwoWire interface
   int32_t _sensorID; //!< ID of the BME Sensor
   int32_t t_fine; //!< temperature with high resolution, stored as an attribute
                   //!< as this is used for temperature compensation reading
                   //!< humidity and pressure
+  uint8_t _i2caddr;  //!< I2C addr for the TwoWire interface
 
   int8_t _cs;   //!< for the SPI interface
   int8_t _mosi; //!< for the SPI interface

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -226,7 +226,6 @@ protected:
   uint8_t read8(byte reg);
   uint16_t read16(byte reg);
   uint32_t read24(byte reg);
-  int16_t readS16(byte reg);
   uint16_t read16_LE(byte reg); // little endian
   int16_t readS16_LE(byte reg); // little endian
 


### PR DESCRIPTION
BMP280 is register downwards-compatible with a BME280, so we
could allow using it against BMP280 as well and avoid duplicate
code for projects wanting to support either BMP or BME280.
