### PR TITLE
Addional I2C overloads to begin

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -69,6 +69,8 @@ Adafruit_BME280::Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin,
 bool Adafruit_BME280::begin(TwoWire *theWire) {
   _wire = theWire;
   _i2caddr = BME280_ADDRESS;
+  _sda = PIN_WIRE_SDA;
+  _scl = PIN_WIRE_SCL;
   return init();
 }
 
@@ -80,6 +82,8 @@ bool Adafruit_BME280::begin(TwoWire *theWire) {
 bool Adafruit_BME280::begin(uint8_t addr) {
   _i2caddr = addr;
   _wire = &Wire;
+  _sda = PIN_WIRE_SDA;
+  _scl = PIN_WIRE_SCL;
   return init();
 }
 
@@ -92,6 +96,39 @@ bool Adafruit_BME280::begin(uint8_t addr) {
 bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
   _i2caddr = addr;
   _wire = theWire;
+  _sda = PIN_WIRE_SDA;
+  _scl = PIN_WIRE_SCL;
+  return init();
+}
+
+/*!
+ *   @brief  Initialise sensor with given parameters / settings
+ *   @param addr the I2C address the device can be found on
+ *   @param sdapin the pin to use for I2C SDA
+ *   @param sclpin the pin to use for I2C SCL
+ *   @returns true on success, false otherwise
+ */
+bool Adafruit_BME280::begin(uint8_t addr, int8_t sdapin, int8_t sclpin) {
+  _i2caddr = addr;
+  _wire = &Wire;
+  _sda = sdapin;
+  _scl = sclpin;
+  return init();
+}
+
+/*!
+ *   @brief  Initialise sensor with given parameters / settings
+ *   @param addr the I2C address the device can be found on
+ *   @param sdapin the pin to use for I2C SDA
+ *   @param sclpin the pin to use for I2C SCL
+ *   @param theWire the I2C object to use
+ *   @returns true on success, false otherwise
+ */
+bool Adafruit_BME280::begin(uint8_t addr, int8_t sdapin, int8_t sclpin, TwoWire *theWire) {
+  _i2caddr = addr;
+  _wire = theWire;
+  _sda = sdapin;
+  _scl = sclpin;
   return init();
 }
 
@@ -101,6 +138,8 @@ bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
  */
 bool Adafruit_BME280::begin(void) {
   bool status = false;
+  _sda = PIN_WIRE_SDA;
+  _scl = PIN_WIRE_SCL;
   _i2caddr = BME280_ADDRESS;
   _wire = &Wire;
   status = init();
@@ -119,7 +158,7 @@ bool Adafruit_BME280::init() {
   // init I2C or SPI sensor interface
   if (_cs == -1) {
     // I2C
-    _wire->begin();
+    _wire->begin(_sda, _scl);
   } else {
     digitalWrite(_cs, HIGH);
     pinMode(_cs, OUTPUT);

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -197,6 +197,8 @@ public:
   bool begin(TwoWire *theWire);
   bool begin(uint8_t addr);
   bool begin(uint8_t addr, TwoWire *theWire);
+  bool begin(uint8_t addr, int8_t sdapin, int8_t sclpin);
+  bool begin(uint8_t addr, int8_t sdapin, int8_t sclpin, TwoWire *theWire);
   bool init();
 
   void setSampling(sensor_mode mode = MODE_NORMAL,
@@ -240,6 +242,9 @@ protected:
   int8_t _mosi; //!< for the SPI interface
   int8_t _miso; //!< for the SPI interface
   int8_t _sck;  //!< for the SPI interface
+
+  int8_t _sda; //!< for the I2C interface
+  int8_t _scl;  //!< for the I2C interface
 
   bme280_calib_data _bme280_calib; //!< here calibration data is stored
 


### PR DESCRIPTION
A couple of additional overloads to the bme.begin function to allow specification of SDA and SCL pins.
I needed this for the library to work on my Digistump Oaks (ESP8266) with a Pimoroni BME280

- **Scope of change**
Fairly simple really, so should be pretty safe (I fink...)
added properties _scl and _sda to .h file.
In .cpp file these should default to compiler definitions for the pins (which are already required for the library to compile)
added two new overloads to the BME begin function, to allow specification of SCL and SDA pins.
added _scl and _sda configuration to all I2C begin overloads
updated I2C begin method in init to specify SCL and SDA pins.

- **Describe any known limitations with your change.** 
Limited testing across platforms, but it should be pretty safe I think. 
I used this on a Digistump Oak (ESP 8266 based) with the Arduino ESP libs (in native ESP mode, not the lapsed Oak-Particle integration).

- **Please run any tests or examples that can exercise your modified code.**
Tests of the various I2C begins appear to work OK, but would recommend some alternative platform checks to be on the safe side.



