### PR TITLE
Add alternate address to 'begfin(TwoWire)'

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -63,13 +63,33 @@ Adafruit_BME280::Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin,
 
 /*!
  *   @brief  Initialise sensor with given parameters / settings
+ *   @param addr the I2C address the device can be found on
+ *   @param theWire the I2C object to use
+ *   @returns true on success, false otherwise
+ */
+bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
+  bool status = false;
+  _i2caddr = addr;
+  _wire = theWire;
+  status = init();
+  if ((!status) && (addr != BME280_ADDRESS)) {
+    _i2caddr = BME280_ADDRESS;
+    status = init();
+  }
+  if ((!status) && (addr != BME280_ADDRESS_ALTERNATE)) {
+    _i2caddr = BME280_ADDRESS_ALTERNATE;
+    status = init();
+  }
+  return status;
+}
+
+/*!
+ *   @brief  Initialise sensor with given parameters / settings
  *   @param theWire the I2C object to use
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(TwoWire *theWire) {
-  _wire = theWire;
-  _i2caddr = BME280_ADDRESS;
-  return init();
+  return begin(BME280_ADDRESS, theWire);
 }
 
 /*!
@@ -78,21 +98,7 @@ bool Adafruit_BME280::begin(TwoWire *theWire) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(uint8_t addr) {
-  _i2caddr = addr;
-  _wire = &Wire;
-  return init();
-}
-
-/*!
- *   @brief  Initialise sensor with given parameters / settings
- *   @param addr the I2C address the device can be found on
- *   @param theWire the I2C object to use
- *   @returns true on success, false otherwise
- */
-bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
-  _i2caddr = addr;
-  _wire = theWire;
-  return init();
+  return begin(addr, &Wire);
 }
 
 /*!
@@ -100,15 +106,7 @@ bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(void) {
-  bool status = false;
-  _i2caddr = BME280_ADDRESS;
-  _wire = &Wire;
-  status = init();
-  if (!status) {
-    _i2caddr = BME280_ADDRESS_ALTERNATE;
-    status = init();
-  }
-  return status;
+  return begin(BME280_ADDRESS, &Wire);
 }
 
 /*!


### PR DESCRIPTION
- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**  This will help us understand any risks of integrating
  the code.

When calling begin(void), if failed to init() with i2caddr=BME280_ADDRESS, it tries again with i2caddr=BME280_ADDRESS_ALTERNATE.
But it does not try again when calling begin(TwoWire). So I added that.

- **Please run any tests or examples that can exercise your modified code.**  We
  strive to not break users of the code and running tests/examples helps with this
  process.

examples/bme280test/bme280test.ino

```c
line 46
-  status = bme.begin();
+  status = bme.begin(&Wire);  
```