### PR TITLE
Change begin() to check both I2C addrs only if addr not passed

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -79,12 +79,7 @@ bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(TwoWire *theWire) {
-  bool status = false;
-  status = begin(BME280_ADDRESS, theWire);
-  if (!status) {
-    status = begin(BME280_ADDRESS_ALTERNATE, theWire);
-  }
-  return status;
+  return begin(BME280_ADDRESS, theWire);
 }
 
 /*!
@@ -101,7 +96,7 @@ bool Adafruit_BME280::begin(uint8_t addr) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(void) {
-  return begin(&Wire);
+  return begin(BME280_ADDRESS, &Wire);
 }
 
 /*!

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -82,7 +82,7 @@ bool Adafruit_BME280::begin(TwoWire *theWire) {
   bool status = false;
   status = begin(BME280_ADDRESS, theWire);
   if (!status) {
-  	status = begin(BME280_ADDRESS_ALTERNATE, theWire);
+    status = begin(BME280_ADDRESS_ALTERNATE, theWire);
   }
   return status;
 }

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -68,19 +68,9 @@ Adafruit_BME280::Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin,
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
-  bool status = false;
   _i2caddr = addr;
   _wire = theWire;
-  status = init();
-  if ((!status) && (addr != BME280_ADDRESS)) {
-    _i2caddr = BME280_ADDRESS;
-    status = init();
-  }
-  if ((!status) && (addr != BME280_ADDRESS_ALTERNATE)) {
-    _i2caddr = BME280_ADDRESS_ALTERNATE;
-    status = init();
-  }
-  return status;
+  return init();
 }
 
 /*!
@@ -89,7 +79,12 @@ bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(TwoWire *theWire) {
-  return begin(BME280_ADDRESS, theWire);
+  bool status = false;
+  status = begin(BME280_ADDRESS, theWire);
+  if (!status) {
+  	status = begin(BME280_ADDRESS_ALTERNATE, theWire);
+  }
+  return status;
 }
 
 /*!
@@ -106,7 +101,7 @@ bool Adafruit_BME280::begin(uint8_t addr) {
  *   @returns true on success, false otherwise
  */
 bool Adafruit_BME280::begin(void) {
-  return begin(BME280_ADDRESS, &Wire);
+  return begin(&Wire);
 }
 
 /*!


### PR DESCRIPTION
The begin() method currently checks the I2C address that was passed (or the base address 0x77), and if that fails, it checks the other address (base 0x77 or alternate 0x76).  This can cause a false success return if two sensors are being used and one is successful and the other is not.  In this case, both sensor objects will return success but point to the same device address.

Checking both addresses should only be done if no address was passed (e.g. `begin(void)` or `begin(TwoWire*)`).  In cases where the address is passed, only that address should be checked (`begin(addr)` or `begin(addr, TwoWire*)`).

Test can be done using one BME280 sensor on address 0x76 with the following code:

```
Adafruit_BME280 bme1, bme2;

bool rc1 = bme1.begin(0x77);  // should be false
bool rc2 = bme2.begin(0x76);  // should be true

rc1 = bme1.begin();  // should be true because both addresses were checked

```
 
Note that prior to this change, all of the above begin() calls would return true because both addresses were always checked.
