### PR TITLE
Add timeout to takeForcedMeasurement

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -343,8 +343,11 @@ uint32_t Adafruit_BME280::read24(byte reg) {
 
 /*!
  *  @brief  Take a new measurement (only possible in forced mode)
+ *  @returns False if timeout has happeded, true in case successful read
  */
-void Adafruit_BME280::takeForcedMeasurement() {
+bool Adafruit_BME280::takeForcedMeasurement() {
+  unsigned long start_time = millis();
+  bool before_timeout = true;
   // If we are in forced mode, the BME sensor goes back to sleep after each
   // measurement and we need to set it to forced mode once at this point, so
   // it will take the next measurement and then return to sleep again.
@@ -354,9 +357,11 @@ void Adafruit_BME280::takeForcedMeasurement() {
     write8(BME280_REGISTER_CONTROL, _measReg.get());
     // wait until measurement has been completed, otherwise we would read
     // the values from the last measurement
-    while (read8(BME280_REGISTER_STATUS) & 0x08)
+    while (read8(BME280_REGISTER_STATUS) & 0x08 && (before_timeout = (millis()-start_time)<1000) )
       delay(1);
   }
+  return before_timeout;
+
 }
 
 /*!

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -357,11 +357,11 @@ bool Adafruit_BME280::takeForcedMeasurement() {
     write8(BME280_REGISTER_CONTROL, _measReg.get());
     // wait until measurement has been completed, otherwise we would read
     // the values from the last measurement
-    while (read8(BME280_REGISTER_STATUS) & 0x08 && (before_timeout = (millis()-start_time)<1000) )
+    while (read8(BME280_REGISTER_STATUS) & 0x08 &&
+           (before_timeout = (millis() - start_time) < 1000))
       delay(1);
   }
   return before_timeout;
-
 }
 
 /*!

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -225,7 +225,7 @@ public:
                    sensor_filter filter = FILTER_OFF,
                    standby_duration duration = STANDBY_MS_0_5);
 
-  void takeForcedMeasurement();
+  bool takeForcedMeasurement();
   float readTemperature(void);
   float readPressure(void);
   float readHumidity(void);


### PR DESCRIPTION
This PR resolves (at least for us :) ) #75 
takeForcedMeasurement returns bool value to let code recognize if readings are available for use.