### PR TITLE
Provide temperature compensation #84

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -545,7 +545,7 @@ uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
  *   @returns the current temperature compensation value in degrees Celcius
  */
 float Adafruit_BME280::getTemperatureCompensation(void) {
-  return float(((t_fine_adjust*5)>>8)/100);
+  return float(((t_fine_adjust * 5) >> 8) / 100);
 };
 
 /*!

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -545,7 +545,7 @@ uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
  *   @returns the current temperature compensation value in degrees Celcius
  */
 float Adafruit_BME280::getTemperatureAdjustment(void) {
-  return 0.0;
+  return float(((t_fine_adjust*5)>>8)/100);
 };
 
 /*!

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -419,7 +419,7 @@ float Adafruit_BME280::readTemperature(void) {
           ((int32_t)_bme280_calib.dig_T3)) >>
          14;
 
-  t_fine = var1 + var2;
+  t_fine = var1 + var2 + t_fine_adjust;
 
   float T = (t_fine * 5 + 128) >> 8;
   return T / 100;
@@ -539,6 +539,24 @@ float Adafruit_BME280::seaLevelForAltitude(float altitude, float atmospheric) {
  *   @returns Sensor ID 0x60 for BME280, 0x56, 0x57, 0x58 BMP280
  */
 uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
+
+/*!
+ *   Returns the current temperature compensation value in degrees Celcius
+ *   @returns the current temperature compensation value in degrees Celcius
+ */
+float Adafruit_BME280::getTemperatureAdjustment(void) {
+  return 0.0;
+};
+
+/*!
+ *  Sets a value to be added to each temperature reading. This adjusted
+ *  temperature is used in pressure and humidity readings.
+ *  @params  adjustment  Value to be added to each tempature reading in Celcius
+ */
+void Adafruit_BME280::setTemperatureAdjustment(float adjustment) {
+  // convert the value in C into and adjustment to t_fine
+  t_fine_adjust = ((int32_t(adjustment * 100) << 8)) / 5;
+};
 
 /*!
     @brief  Gets an Adafruit Unified Sensor object for the temp sensor component

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -551,7 +551,7 @@ float Adafruit_BME280::getTemperatureCompensation(void) {
 /*!
  *  Sets a value to be added to each temperature reading. This adjusted
  *  temperature is used in pressure and humidity readings.
- *  @params  adjustment  Value to be added to each tempature reading in Celcius
+ *  @param  adjustment  Value to be added to each tempature reading in Celcius
  */
 void Adafruit_BME280::setTemperatureCompensation(float adjustment) {
   // convert the value in C into and adjustment to t_fine

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -544,7 +544,7 @@ uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
  *   Returns the current temperature compensation value in degrees Celcius
  *   @returns the current temperature compensation value in degrees Celcius
  */
-float Adafruit_BME280::getTemperatureAdjustment(void) {
+float Adafruit_BME280::getTemperatureCompensation(void) {
   return float(((t_fine_adjust*5)>>8)/100);
 };
 
@@ -553,7 +553,7 @@ float Adafruit_BME280::getTemperatureAdjustment(void) {
  *  temperature is used in pressure and humidity readings.
  *  @params  adjustment  Value to be added to each tempature reading in Celcius
  */
-void Adafruit_BME280::setTemperatureAdjustment(float adjustment) {
+void Adafruit_BME280::setTemperatureCompensation(float adjustment) {
   // convert the value in C into and adjustment to t_fine
   t_fine_adjust = ((int32_t(adjustment * 100) << 8)) / 5;
 };

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -277,8 +277,8 @@ protected:
   int8_t _miso; //!< for the SPI interface
   int8_t _sck;  //!< for the SPI interface
 
-  int32_t t_fine_adjust; //!< add to compensate temp readings and in turn to
-                         //!< pressure and humidity readings
+  int32_t t_fine_adjust = 0; //!< add to compensate temp readings and in turn
+                             //!< to pressure and humidity readings
 
   bme280_calib_data _bme280_calib; //!< here calibration data is stored
 

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -234,6 +234,9 @@ public:
   float seaLevelForAltitude(float altitude, float pressure);
   uint32_t sensorID(void);
 
+  float getTemperatureAdjustment(void);
+  void setTemperatureAdjustment(float);
+
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getPressureSensor(void);
   Adafruit_Sensor *getHumiditySensor(void);
@@ -273,6 +276,9 @@ protected:
   int8_t _mosi; //!< for the SPI interface
   int8_t _miso; //!< for the SPI interface
   int8_t _sck;  //!< for the SPI interface
+
+  int32_t t_fine_adjust; //!< add to compensate temp readings and in turn to
+                       //!< pressure and humidity readings
 
   bme280_calib_data _bme280_calib; //!< here calibration data is stored
 

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -278,7 +278,7 @@ protected:
   int8_t _sck;  //!< for the SPI interface
 
   int32_t t_fine_adjust; //!< add to compensate temp readings and in turn to
-                       //!< pressure and humidity readings
+                         //!< pressure and humidity readings
 
   bme280_calib_data _bme280_calib; //!< here calibration data is stored
 

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -234,8 +234,8 @@ public:
   float seaLevelForAltitude(float altitude, float pressure);
   uint32_t sensorID(void);
 
-  float getTemperatureAdjustment(void);
-  void setTemperatureAdjustment(float);
+  float getTemperatureCompensation(void);
+  void setTemperatureCompensation(float);
 
   Adafruit_Sensor *getTemperatureSensor(void);
   Adafruit_Sensor *getPressureSensor(void);


### PR DESCRIPTION
### Scope

A private member field is added to the class ` Adafruit_BME280`: `float t_fine_adjust`

### Limitations

A few degrees Celsius of temperature compensation result in only tiny changes in pressure and humidity.

```
Adjustment: 3
28.66 - 100066.50 - 30.76
Adjustment: 0
25.65 -- 99553.88 - 30.81
Adjustment: 3
28.71 - 100069.04 - 32.90
Adjustment: 0
25.73 -- 99555.32 - 34.43
```

Running:
```
#include <Arduino.h>
#include <Wire.h>
#include <SPI.h>
#include <Adafruit_Sensor.h>
#include <Adafruit_BME280.h>

Adafruit_BME280 bme; // I2C

void setup() {
  Serial.begin(9600);
  if (! bme.begin(BME280_ADDRESS_ALTERNATE, &Wire)) {
    Serial.println("badness");
    while(1);
  }
  // bme.setTemperatureAdjustment(3);
}

void loop() {
  bme.setTemperatureAdjustment(3);
  Serial.println("Adjustment: 3");
  Serial.print(bme.readTemperature());
  Serial.print(" - ");
  Serial.print(bme.readPressure());
  Serial.print(" - ");
  Serial.println(bme.readHumidity());
  delay(1000);
  bme.setTemperatureAdjustment(0);
  Serial.println("Adjustment: 0");
  Serial.print(bme.readTemperature());
  Serial.print(" -- ");
  Serial.print(bme.readPressure());
  Serial.print(" - ");
  Serial.println(bme.readHumidity());
  delay(5000);
}
```