### PR TITLE
Fix incorrect float return value from getTemperatureCompensation()

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -545,7 +545,7 @@ uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
  *   @returns the current temperature compensation value in degrees Celcius
  */
 float Adafruit_BME280::getTemperatureCompensation(void) {
-  return float(((t_fine_adjust * 5) >> 8) / 100);
+  return float((t_fine_adjust * 5) >> 8) / 100.0;
 };
 
 /*!


### PR DESCRIPTION
This fixes a minor bug in the return value of getTemperatureCompensation().
getTemperatureCompensation() was dropping (rounding to integer) the fractional part of the temperature offset due to an integer divide by 100 before returning it as a float.

For example: if the temperature compensation was 1.49 degC, the value returned was 1.00

This didn't affect the accuracy of the readings (setTemperatureCompensation() worked fine),
it only gave an incorrect value if you read the value back using getTemperatureCompensation()

My fix just returns the correct value with the intended resolution of 0.01 degC by dividing by 100 in floating point math.

To test:
set a temperature compensation value of 1.49 degrees with setTemperatureCompensation()
read the value back using getTemperatureCompensation()
the returned value should be 1.49 (previously it was 1.00)

This obviously applies to all platforms equally (it's just floating point math)
