### PR TITLE
Default to correct I2C ID for BME280

### DIFF
--- a/examples/bme280test/bme280test.ino
+++ b/examples/bme280test/bme280test.ino
@@ -42,7 +42,8 @@ void setup() {
     unsigned status;
     
     // default settings
-    status = bme.begin();  
+    status = bme.begin(0x76); // I2C
+    // status = bme.begin(); // SPI
     // You can also pass in a Wire library object like &Wire2
     // status = bme.begin(0x76, &Wire2)
     if (!status) {


### PR DESCRIPTION
The upstream library is defaulting to 0xFF for the I2C ID, but the BME280 uses 0x76 (0x77 w/ jumper). This confused at least one noob I'm aware of, so I feel like it makes sense to have a good default here.
