### PR TITLE
Convert to BusIO

### DIFF
--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -23,9 +23,9 @@
 
 #include "Arduino.h"
 
+#include <Adafruit_I2CDevice.h>
+#include <Adafruit_SPIDevice.h>
 #include <Adafruit_Sensor.h>
-#include <SPI.h>
-#include <Wire.h>
 
 /*!
  *  @brief  default I2C address
@@ -242,8 +242,8 @@ public:
   Adafruit_Sensor *getHumiditySensor(void);
 
 protected:
-  TwoWire *_wire; //!< pointer to a TwoWire object
-  SPIClass *_spi; //!< pointer to SPI object
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
 
   Adafruit_BME280_Temp *temp_sensor = NULL;
   //!< Adafruit_Sensor compat temperature sensor component
@@ -256,7 +256,6 @@ protected:
 
   void readCoefficients(void);
   bool isReadingCalibration(void);
-  uint8_t spixfer(uint8_t x);
 
   void write8(byte reg, byte value);
   uint8_t read8(byte reg);
@@ -271,11 +270,6 @@ protected:
   int32_t t_fine; //!< temperature with high resolution, stored as an attribute
                   //!< as this is used for temperature compensation reading
                   //!< humidity and pressure
-
-  int8_t _cs;   //!< for the SPI interface
-  int8_t _mosi; //!< for the SPI interface
-  int8_t _miso; //!< for the SPI interface
-  int8_t _sck;  //!< for the SPI interface
 
   int32_t t_fine_adjust = 0; //!< add to compensate temp readings and in turn
                              //!< to pressure and humidity readings

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BME280 Library
-version=2.1.4
+version=2.2.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BME280 sensors.
@@ -7,4 +7,4 @@ paragraph=Arduino library for BME280 humidity and pressure sensors.
 category=Sensors
 url=https://github.com/adafruit/Adafruit_BME280_Library
 architectures=*
-depends=Adafruit Unified Sensor
+depends=Adafruit Unified Sensor, Adafruit BusIO


### PR DESCRIPTION
For #96. (ignore iss tag in branch name, not sure where 23 came from)

Converts to BusIO usage. Tested with `bme280test.ino` example from library on Qt PY using both I2C and SPI.
![Screenshot from 2021-07-30 16-14-12](https://user-images.githubusercontent.com/8755041/127720297-cf6fd40c-831f-461f-9151-465d26d8d20b.png)
