### PR TITLE
Tweak memory alloc and cleanup

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -60,6 +60,12 @@ Adafruit_BME280::Adafruit_BME280(int8_t cspin, int8_t mosipin, int8_t misopin,
 }
 
 Adafruit_BME280::~Adafruit_BME280(void) {
+  if (spi_dev) {
+    delete spi_dev;
+  }
+  if (i2c_dev) {
+    delete i2c_dev;
+  }
   if (temp_sensor) {
     delete temp_sensor;
   }
@@ -79,10 +85,14 @@ Adafruit_BME280::~Adafruit_BME280(void) {
  */
 bool Adafruit_BME280::begin(uint8_t addr, TwoWire *theWire) {
   if (spi_dev == NULL) {
+    // I2C mode
+    if (i2c_dev)
+      delete i2c_dev;
     i2c_dev = new Adafruit_I2CDevice(addr, theWire);
     if (!i2c_dev->begin())
       return false;
   } else {
+    // SPI mode
     if (!spi_dev->begin())
       return false;
   }

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BME280 Library
-version=2.2.0
+version=2.2.1
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BME280 sensors.


### PR DESCRIPTION
Cleaning up this one too.

```cpp
#include <Adafruit_BME280.h>

Adafruit_BME280 bme;

void setup() {
  Serial.begin(9600);
  while (!Serial);
  Serial.println(F("BME280 multiple begin() call test"));         
}

void loop() {
  if (!bme.begin()) {
    Serial.println(F("Could not find a valid BME280 sensor, check wiring or "
                      "try a different address!"));
    while (1) delay(10);
  }

  Serial.print(F("Pressure = "));
  Serial.print(bme.readPressure());
  Serial.println(" Pa");

  delay(1000);
}
```

![Screenshot from 2021-08-24 10-20-20](https://user-images.githubusercontent.com/8755041/130661624-1125e6cf-7bb3-4e34-9a48-3cf1894443ff.png)
