### PR TITLE
Return NaN only if sampling is disabled

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -338,10 +338,10 @@ bool Adafruit_BME280::isReadingCalibration(void) {
  */
 float Adafruit_BME280::readTemperature(void) {
   int32_t var1, var2;
+  if (_measReg.osrs_t == sensor_sampling::SAMPLING_NONE)
+    return NAN;
 
   int32_t adc_T = read24(BME280_REGISTER_TEMPDATA);
-  if (adc_T == 0x800000) // value in case temp measurement was disabled
-    return NAN;
   adc_T >>= 4;
 
   var1 = (int32_t)((adc_T / 8) - ((int32_t)_bme280_calib.dig_T1 * 2));
@@ -362,12 +362,12 @@ float Adafruit_BME280::readTemperature(void) {
  */
 float Adafruit_BME280::readPressure(void) {
   int64_t var1, var2, var3, var4;
+  if (_measReg.osrs_p == sensor_sampling::SAMPLING_NONE)
+    return NAN;
 
   readTemperature(); // must be done first to get t_fine
 
   int32_t adc_P = read24(BME280_REGISTER_PRESSUREDATA);
-  if (adc_P == 0x800000) // value in case pressure measurement was disabled
-    return NAN;
   adc_P >>= 4;
 
   var1 = ((int64_t)t_fine) - 128000;
@@ -401,13 +401,12 @@ float Adafruit_BME280::readPressure(void) {
  */
 float Adafruit_BME280::readHumidity(void) {
   int32_t var1, var2, var3, var4, var5;
+  if (_humReg.osrs_h == sensor_sampling::SAMPLING_NONE)
+    return NAN;
 
   readTemperature(); // must be done first to get t_fine
 
   int32_t adc_H = read16(BME280_REGISTER_HUMIDDATA);
-  if (adc_H == 0x8000) // value in case humidity measurement was disabled
-    return NAN;
-
   var1 = t_fine - ((int32_t)76800);
   var2 = (int32_t)(adc_H * 16384);
   var3 = (int32_t)(((int32_t)_bme280_calib.dig_H4) * 1048576);

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -132,8 +132,6 @@ bool Adafruit_BME280::init() {
 /*!
  *   @brief  setup sensor with given parameters / settings
  *
- *   This is simply a overload to the normal begin()-function, so SPI users
- *   don't get confused about the library requiring an address.
  *   @param mode the power mode to use for the sensor
  *   @param tempSampling the temp samping rate to use
  *   @param pressSampling the pressure sampling rate to use

--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -334,7 +334,7 @@ bool Adafruit_BME280::isReadingCalibration(void) {
 
 /*!
  *   @brief  Returns the temperature from the sensor
- *   @returns the temperature read from the device
+ *   @returns the temperature read from the device or NaN if sampling off
  */
 float Adafruit_BME280::readTemperature(void) {
   int32_t var1, var2;
@@ -358,7 +358,7 @@ float Adafruit_BME280::readTemperature(void) {
 
 /*!
  *   @brief  Returns the pressure from the sensor
- *   @returns the pressure value (in Pascal) read from the device
+ *   @returns the pressure value (in Pascal) or NaN if sampling off
  */
 float Adafruit_BME280::readPressure(void) {
   int64_t var1, var2, var3, var4;
@@ -397,7 +397,7 @@ float Adafruit_BME280::readPressure(void) {
 
 /*!
  *  @brief  Returns the humidity from the sensor
- *  @returns the humidity value read from the device
+ *  @returns the humidity value read from the device or NaN if sampling off
  */
 float Adafruit_BME280::readHumidity(void) {
   int32_t var1, var2, var3, var4, var5;

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -354,14 +354,14 @@ protected:
     /// unused - don't set
     unsigned int none : 5;
 
-    // pressure oversampling
+    // humidity oversampling
     // 000 = skipped
     // 001 = x1
     // 010 = x2
     // 011 = x4
     // 100 = x8
     // 101 and above = x16
-    unsigned int osrs_h : 3; ///< pressure oversampling
+    unsigned int osrs_h : 3; ///< humidity oversampling
 
     /// @return combined ctrl hum register
     unsigned int get() { return (osrs_h); }

--- a/examples/advancedsettings/advancedsettings.ino
+++ b/examples/advancedsettings/advancedsettings.ino
@@ -2,7 +2,7 @@
   This is a library for the BME280 humidity, temperature & pressure sensor
 
   Designed specifically to work with the Adafruit BME280 Breakout
-  ----> http://www.adafruit.com/products/2650
+  ----> http://www.adafruit.com/products/2652
 
   These sensors use I2C or SPI to communicate, 2 or 4 pins are required
   to interface. The device's I2C address is either 0x76 or 0x77.

--- a/examples/bme280test/bme280test.ino
+++ b/examples/bme280test/bme280test.ino
@@ -2,7 +2,7 @@
   This is a library for the BME280 humidity, temperature & pressure sensor
 
   Designed specifically to work with the Adafruit BME280 Breakout
-  ----> http://www.adafruit.com/products/2650
+  ----> http://www.adafruit.com/products/2652
 
   These sensors use I2C or SPI to communicate, 2 or 4 pins are required
   to interface. The device's I2C address is either 0x76 or 0x77.

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit BME280 Library
-version=2.2.4
+version=2.3.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for BME280 sensors.


### PR DESCRIPTION
This changes the functionality for pressure/temperature/humidity from returning NaN at key values (fixed values returned when sampling rate is None/Skip), to returning NaN if sampling is off.

Minor docstring changes too.

Tested on MetroS3 w/BME280, using simple test and advanced test with humidty test scenario (shows pressure and altitude return nan as pressure sampling is off).

Not verified that exactly 80% relative humidity can be returned (but logically ok).