### PR TITLE
Added sensorConnected() function to check active connection to sensor

### DIFF
--- a/Adafruit_BME280.cpp
+++ b/Adafruit_BME280.cpp
@@ -469,6 +469,22 @@ float Adafruit_BME280::seaLevelForAltitude(float altitude, float atmospheric) {
 uint32_t Adafruit_BME280::sensorID(void) { return _sensorID; }
 
 /*!
+ *   Checks sensor ID to confirm connection to sensor. 
+ *   @returns Sensor ID 0x60 for BME280
+ *   or 0x00 on failure
+ *   IWH 10/04/2026
+ */
+uint32_t Adafruit_BME280::sensorConnected(void){
+	uint32_t sensor = read8(BME280_REGISTER_CHIPID);
+  if (sensor != 0x60){
+    return 0x00;
+  } else {
+	return sensor;
+  }
+}	
+	
+
+/*!
  *   Returns the current temperature compensation value in degrees Celsius
  *   @returns the current temperature compensation value in degrees Celsius
  */

--- a/Adafruit_BME280.h
+++ b/Adafruit_BME280.h
@@ -232,7 +232,8 @@ public:
 
   float readAltitude(float seaLevel);
   float seaLevelForAltitude(float altitude, float pressure);
-  uint32_t sensorID(void);
+  uint32_t sensorID(void);   // return sensorID from init
+  uint32_t sensorConnected(void);   // Active check of sensor ID to check valid connection  IWH 10/04/2026
 
   float getTemperatureCompensation(void);
   void setTemperatureCompensation(float);


### PR DESCRIPTION
Submitted against issue: https://github.com/adafruit/Adafruit_BME280_Library/issues/112

I have added a checkConnection() method that checks the sensor ID using the same method as init. It will return the correct sensor code for BME280 on success, or 0x00 on failure.
This allows users to check for an active connection and resopond to lack of communication, for example by power cycling the bus.

No known limitations
  
I have run against all included examples, as new method does not modify existing methods it should not break any existing functionality


